### PR TITLE
Remove example specific `fileIO`

### DIFF
--- a/Examples/BazelXCBBuildService/Sources/RequestHandler.swift
+++ b/Examples/BazelXCBBuildService/Sources/RequestHandler.swift
@@ -22,7 +22,13 @@ final class RequestHandler: HybridXCBBuildServiceRequestHandler {
     
     // We use negative numbers to ensure no duplication with XCBBuildService (though it seems that doesn't matter)
     private var lastBazelBuildNumber: Int64 = 0
-    
+
+    private let fileIO: NonBlockingFileIO
+
+    init(fileIO: NonBlockingFileIO) {
+        self.fileIO = fileIO
+    }
+
     func handleRequest(_ request: RPCRequest<BazelXCBBuildServiceRequestPayload>, context: Context) {
         // Unless `forwardRequest` is set to `false`, at the end we forward the request to XCBBuildService
         var shouldForwardRequest = true

--- a/Examples/BazelXCBBuildService/Sources/main.swift
+++ b/Examples/BazelXCBBuildService/Sources/main.swift
@@ -30,8 +30,7 @@ do {
     let service = try HybridXCBBuildService(
         name: "BazelXCBBuildService",
         group: group,
-        fileIO: fileIO,
-        requestHandler: RequestHandler()
+        requestHandler: RequestHandler(fileIO: fileIO)
     )
 
     do {

--- a/Sources/XCBBuildServiceProxyKit/Hybrid/HybridRPCRequestHandler.swift
+++ b/Sources/XCBBuildServiceProxyKit/Hybrid/HybridRPCRequestHandler.swift
@@ -15,14 +15,12 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
     typealias Request = InboundIn
     typealias Response = OutboundIn
     
-    private let fileIO: NonBlockingFileIO
     private let xcbBuildService: XCBBuildService
     private let requestHandler: RequestHandler
     
     private var responsePromises: [UInt64: EventLoopPromise<Response>] = [:]
     
-    init(fileIO: NonBlockingFileIO, xcbBuildService: XCBBuildService, requestHandler: RequestHandler) {
-        self.fileIO = fileIO
+    init(xcbBuildService: XCBBuildService, requestHandler: RequestHandler) {
         self.xcbBuildService = xcbBuildService
         self.requestHandler = requestHandler
     }

--- a/Sources/XCBBuildServiceProxyKit/Hybrid/HybridXCBBuildService.swift
+++ b/Sources/XCBBuildServiceProxyKit/Hybrid/HybridXCBBuildService.swift
@@ -9,7 +9,7 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
     private let bootstrap: NIOPipeBootstrap
     
     // TODO: Move NIO specific stuff into class
-    public init(name: String, group: EventLoopGroup, fileIO: NonBlockingFileIO, requestHandler: RequestHandler) throws {
+    public init(name: String, group: EventLoopGroup, requestHandler: RequestHandler) throws {
         self.name = name
         self.group = group
         
@@ -33,7 +33,6 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
                         RPCResponseEncoder<RequestHandler.ResponsePayload>(),
                         // RPCRequests from Xcode, RPCResponses from XCBBuildService
                         HybridRPCRequestHandler<RequestHandler>(
-                            fileIO: fileIO,
                             xcbBuildService: xcbBuildService,
                             requestHandler: requestHandler
                         ),


### PR DESCRIPTION
**Problem**

`fileIO` in `HybridRPCRequestHandler` API is not really used for that API specific
but only used for example use case, which is not necessary to be a part of API
I believe.
Because of this, the API user need to provide `fileIO` even if it’s not used at all.

**Solution**

Remove it, also provide `fileIO` within the example code.