### PR TITLE
FIX: Leaking a promise

### DIFF
--- a/Sources/XCBBuildServiceProxyKit/Hybrid/HybridXCBBuildService.swift
+++ b/Sources/XCBBuildServiceProxyKit/Hybrid/HybridXCBBuildService.swift
@@ -25,8 +25,8 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
                     // When the channel for XCBBuildService is closed, such as the process is terminated,
                     // close the channel for Xcode as well, which allows to terminate proxy process.
                     // Xcode then relaunch it when it's needed.
-                    _ = xcbBuildService.channel.closeFuture.flatMap {
-                        channel.close()
+                    xcbBuildService.channel.closeFuture.whenComplete { _ in
+                        channel.close(promise: nil)
                     }
 
                     return channel.pipeline.addHandlers([


### PR DESCRIPTION
**Problem**

In #4, there is a leaking promise introduced, which caused a fatal error.
```
Fatal error: leaking promise created at (file: "...Hybrid/HybridXCBBuildService.swift", line: 30)
```

**Solution**

Instead of throwing the future with `flatMap`, use a callback and call `close()` without a promise.
