### PR TITLE
Ensure `bepFileHandle` is released

### DIFF
--- a/Examples/BazelXCBBuildService/Sources/BazelBuildProcess.swift
+++ b/Examples/BazelXCBBuildService/Sources/BazelBuildProcess.swift
@@ -194,6 +194,10 @@ final class BazelClient: BazelBuildProcess {
         }
         
         processDispatchGroup.notify(queue: processResultsQueue) {
+            if bepFileHandle.readabilityHandler != nil {
+                bepFileHandle.closeFile()
+                bepFileHandle.readabilityHandler = nil
+            }
             terminationHandler(self.process.terminationStatus, self.isCancelled)
             isTerminated = true
         }


### PR DESCRIPTION
ensure bepFileHandle release resource when bepFileHandle has not receive last message. 
for example bazel progress exitcode is not zero